### PR TITLE
Add the ability to specify additional custom ETW providers and events…

### DIFF
--- a/CustomProvider.cs
+++ b/CustomProvider.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace wpt_etw
+{
+    public class CustomProvider
+    {
+        public int Verbosity { get; set; }
+
+        public ulong Filter { get; set; }
+
+        public IList<String> EventNames { get; set; }
+
+        public IList<int> EventIDs { get; set; }
+    }
+}

--- a/customProviders.json
+++ b/customProviders.json
@@ -1,0 +1,10 @@
+﻿{
+  // example custom provider configuration
+  /*
+  "Microsoft.Web.Platform": {
+    "Verbosity": 5,
+    "Filter": 70368744177664,
+    "EventNames": [ "PageAvailable" ],
+    "EventIDs": [ 10322, 10485, 11121 ]
+  }*/
+}

--- a/wpt-etw.csproj
+++ b/wpt-etw.csproj
@@ -68,12 +68,16 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="CustomProvider.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />
     <None Include="app.manifest" />
+    <None Include="customProviders.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="packages.config" />
     <None Include="_TraceEventProgrammersGuide.docx" />
   </ItemGroup>


### PR DESCRIPTION
… via config. The config provides the ability to customize ETW logging verbosity level, event filter, event names and event IDs.

Some newer ETW providers (such as Microsoft.Web.Platform) do not have OS-registered manifests so the event ID can sometimes vary by OS build and/or app version. To work around this the config does not enforce a 1:1 mapping between event name and ID. This allows the same config to support multiple OS/app versions.