### PR TITLE
Remove ExtractWinInetValues function

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -148,15 +148,6 @@ namespace wpt_etw
                                 {
                                     values[name] = data.PayloadByName(name);
                                 }
-                                // Special-case a few events where teh default decoder doesn't work correctly
-                                if (data.ProviderName == "Microsoft-Windows-WinINet")
-                                {
-                                    try
-                                    {
-                                        //ExtractWinInetValues(data, ref values);
-                                    }
-                                    catch { }
-                                }
                                 evt["data"] = values;
                             }
 
@@ -285,84 +276,6 @@ namespace wpt_etw
                 session.Stop();
             }
             catch { }
-        }
-
-        /*
-         * Handle messages that the underlying library doesn't handle correctly (mostly ASCII strings)
-         **/
-        static void ExtractWinInetValues(TraceEvent data, ref Dictionary<string, dynamic> values)
-        {
-            if (data.EventName == "WININET_REQUEST_HEADER" || data.EventName == "WININET_RESPONSE_HEADER")
-            {
-                byte[] raw = data.EventData().Skip(10).ToArray();
-                values["Headers"] = System.Text.Encoding.ASCII.GetString(raw);
-            }
-            else if (data.EventName == "WININET_DNS_QUERY/Start")
-            {
-                byte[] raw = data.EventData().Skip(2).ToArray();
-                int count = 0;
-                foreach (byte c in raw)
-                {
-                    if (c == 0)
-                        break;
-                    count++;
-                }
-                values["HostName"] = System.Text.Encoding.ASCII.GetString(raw.Take(count).ToArray());
-            }
-            else if (data.EventName == "WININET_DNS_QUERY/Stop")
-            {
-                byte[] raw = data.EventData().Skip(2).ToArray();
-                int count = 0;
-                foreach (byte c in raw)
-                {
-                    if (c == 0)
-                        break;
-                    count++;
-                }
-                values["HostName"] = System.Text.Encoding.ASCII.GetString(raw.Take(count).ToArray());
-                // Find the beginning of the address list (numerical characters)
-                raw = raw.Skip(count).ToArray();
-                count = 0;
-                foreach (byte c in raw)
-                {
-                    if (c >= '0' && c <= '9')
-                        break;
-                    count++;
-                }
-                raw = raw.Skip(count).ToArray();
-                values["AddressList"] = System.Text.Encoding.ASCII.GetString(raw);
-            }
-            else if (data.EventName == "WININET_TCP_CONNECTION/Start")
-            {
-                byte[] raw = data.EventData().Skip(2).ToArray();
-                int count = 0;
-                foreach (byte c in raw)
-                {
-                    if (c == 0)
-                        break;
-                    count++;
-                }
-                values["ServerName"] = System.Text.Encoding.ASCII.GetString(raw.Take(count).ToArray());
-            }
-            else if (data.EventName == "Wininet_SendRequest/Stop")
-            {
-                byte[] raw = data.EventData().Reverse().ToArray();
-                int count = 0;
-                foreach (byte c in raw)
-                {
-                    if (c == 0)
-                        break;
-                    count++;
-                }
-                raw = raw.Take(count).Reverse().ToArray();
-                values["StatusLine"] = System.Text.Encoding.ASCII.GetString(raw);
-            }
-            else if (data.EventName == "Wininet_Connect/Stop")
-            {
-                byte[] raw = data.EventData();
-                values["LocalAddress"] = String.Format("{0}.{1}.{2}.{3}", values["LocalAddress"][4], values["LocalAddress"][5], values["LocalAddress"][6], values["LocalAddress"][7]);
-                values["RemoteAddress"] = String.Format("{0}.{1}.{2}.{3}", values["RemoteAddress"][4], values["RemoteAddress"][5], values["RemoteAddress"][6], values["RemoteAddress"][7]);
-            }
         }
     }
 }

--- a/Program.cs
+++ b/Program.cs
@@ -153,7 +153,7 @@ namespace wpt_etw
                                 {
                                     try
                                     {
-                                        ExtractWinInetValues(data, ref values);
+                                        //ExtractWinInetValues(data, ref values);
                                     }
                                     catch { }
                                 }


### PR DESCRIPTION
Following the upgrade to the TraceEvent library, the ExtractWinInetValues function which did some custom parsing of various WinInet events appears to no longer be necessary. This is a very significant performance win because the objects being passed in are dynamically typed. It is the most expensive function in the exe, typically taking 50-60% of CPU time (measured after upgrading to the latest TraceEvent library). 

In a separate branch (https://github.com/amiyagupta/wpt-etw/tree/examine-extract-wininet-values) I've added logging that compares fields before and after ExtractWinInetValues updates them and prints out stats before exiting. In the vast majority of cases the existing field is overwritten by an identical string. In the few cases where the before and after strings do not match, the original string is more correct than the one it is being replaced with. 

All the cases where the before and after strings do not match fall into two categories:
1. Extra trailing characters in ServerName field in WININET_TCP_CONNECTION/Start
2. Extra leading characters in the AddressList field update in WININET_DNS_QUERY/Stop 

```
TcpConnectionStart ServerName modified from
nav.smartscreen.microsoft.com
to
nav.smartscreen.microsoft.com\

DnsQueryStop AddressList modified from
52.9.194.244;54.153.119.33;52.52.19.88;13.56.126.150;
to
5 52.9.194.244;54.153.119.33;52.52.19.88;13.56.126.150; 
```

Some example statistics I gathered while I had the version with logging running and browsing around a large number of popular websites:

```
HeaderOverwrites: 0, HeaderOverWritesWasted: 0
DnsQueryStartOverwrites: 459, DnsQueryStartOverwritesWasted: 459
DnsQueryStopOverwrites: 454, DnsQueryStopOverwritesWasted: 454
DnsQueryStopAddressOverwrites: 454, DnsQueryStopAddressOverwritesWasted: 441
TcpConnectionStartOverwrites: 821, TcpConnectionStartOverwritesWasted: 779
SendRequestStopOverwrites: 2109, SendRequestStopOverwritesWasted: 2109
ConnectStopLocalAddressOverwrites: 0, ConnectStopLocalAddressOverwritesWasted: 0
ConnectStopRemoteAddressOverwrites: 0, ConnectStopRemoteAddressOverwritesWasted: 0
```
 