### PR TITLE
Use StringBuilder to reduce cost of concatenation

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -55,8 +55,7 @@ namespace wpt_etw
             { "Wininet_LookupConnection/Stop", 1048 },
             { "WININET_STREAM_DATA_INDICATED", 1064 }
         };
-
-        //static Stopwatch stopwatch = new Stopwatch();
+        
         static TraceEventSession session;
         static bool must_exit = false;
         private static Mutex mutex = new Mutex();            
@@ -235,28 +234,14 @@ namespace wpt_etw
                     mutex.WaitOne();
                     if (events.Length > 0)
                     {
-                        //Console.WriteLine("\nevents.Length: {0}, events.Capacity: {1}", events.Length, events.Capacity);                        
-                        //stopwatch.Start();
-                        buff = events.ToString();
-                        //stopwatch.Stop();
-                        //Console.WriteLine("    ToString took: {0} ticks", stopwatch.ElapsedTicks);
-                        //stopwatch.Reset();
-
-                        //stopwatch.Start();
+                        buff = events.ToString();                        
                         events.Clear();
-                        //stopwatch.Stop();                        
-                        //Console.WriteLine("    StringBuilder clear took: {0} ticks", stopwatch.ElapsedTicks);
-                        //stopwatch.Reset();
                     }
                     mutex.ReleaseMutex();
 
                     if (buff.Length > 0)
-                    {
-                        //stopwatch.Start();
+                    {                        
                         content = new StringContent(buff, Encoding.UTF8, "application/json");
-                        //stopwatch.Stop();
-                        //Console.WriteLine("    StringContent allocation took: {0} ticks", stopwatch.ElapsedTicks);
-                        //stopwatch.Reset();
                         try
                         {
                             var response = wptagent.PostAsync("http://127.0.0.1:8888/etw", content).Result;

--- a/Program.cs
+++ b/Program.cs
@@ -55,20 +55,20 @@ namespace wpt_etw
             { "Wininet_LookupConnection/Stop", 1048 },
             { "WININET_STREAM_DATA_INDICATED", 1064 }
         };
-        
+
         static TraceEventSession session;
         static bool must_exit = false;
-        private static Mutex mutex = new Mutex();            
+        private static Mutex mutex = new Mutex();
         static StringBuilder events = new StringBuilder(2000000);
         static string body_dir = "";
         static Dictionary<string, CustomProvider> customProviders = new Dictionary<string, CustomProvider>();
-        static string customProvidersConfigPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, @".\customProviders.json");        
+        static string customProvidersConfigPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, @".\customProviders.json");
 
         static void Main(string[] args)
         {
             if (args.Length == 2 && args[0] == "--bodies" && System.IO.Directory.Exists(args[1]))
                 body_dir = args[1];
-            
+
             // read settings for custom ETW providers            
             if (File.Exists(customProvidersConfigPath))
             {
@@ -234,13 +234,13 @@ namespace wpt_etw
                     mutex.WaitOne();
                     if (events.Length > 0)
                     {
-                        buff = events.ToString();                        
+                        buff = events.ToString();
                         events.Clear();
                     }
                     mutex.ReleaseMutex();
 
                     if (buff.Length > 0)
-                    {                        
+                    {
                         content = new StringContent(buff, Encoding.UTF8, "application/json");
                         try
                         {


### PR DESCRIPTION
Replaces the "events" string with a pre-allocated StringBuilder. Repetitive string concatenations were a bottleneck especially when measuring pages that fire lots of requests and generate a large volume of events. 
Based on my observations from some logging, the length of the string seldom exceeded 1-1.2 million even on the heaviest pages; 2 million should be a high enough initial capacity that very rarely triggers additional memory allocation. 