### PR TITLE
Reduce string concatenation

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -153,12 +153,12 @@ namespace wpt_etw
 
                             //evt["ascii"] = System.Text.Encoding.ASCII.GetString(data.EventData());
                             //evt["raw"] = data.EventData();
-                            string json = JsonConvert.SerializeObject(evt) + "\n";
+                            string json = JsonConvert.SerializeObject(evt);
                             // Throw out anything that is for the local server on http://127.0.0.1:8888
                             if (json.IndexOf("http://127.0.0.1:8888") == -1)
                             {
                                 mutex.WaitOne();
-                                events.Append(json);
+                                events.Append(json).Append("\n");                                
                                 mutex.ReleaseMutex();
                             }
                             //Debug.WriteLine(json.Trim());

--- a/Program.cs
+++ b/Program.cs
@@ -158,7 +158,7 @@ namespace wpt_etw
                             if (json.IndexOf("http://127.0.0.1:8888") == -1)
                             {
                                 mutex.WaitOne();
-                                events.Append(json).Append("\n");                                
+                                events.Append(json).Append("\n");
                                 mutex.ReleaseMutex();
                             }
                             //Debug.WriteLine(json.Trim());


### PR DESCRIPTION
Move the concatenation of a newline characters between JSON strings to StringBuilder to reduce allocations. 