### PR TITLE
Warm up the Newtonsoft serializer 

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -79,6 +79,10 @@ namespace wpt_etw
                 catch { }
             }
 
+            // perf optimization - warm up the Json serializer to avoid a big perf hit serializing the first event while the test is running
+            // reduces the observer effect of the exe            
+            var serializedWinInetEvents = JsonConvert.SerializeObject(WinInetEvents);            
+
             // create a real time user mode session
             using (session = new TraceEventSession("wpt-etw"))
             {


### PR DESCRIPTION
The first call to Newtonsoft.Json SerializeObject is very slow, taking 90-100ms on a slower VM. Subsequent calls are 3-4 orders of magnitude faster. 

This change executes a dummy serialization before the test starts in order to avoid paying that cost while the measurement is running, reducing the observer effect. Branch with logging is available [here](
https://github.com/amiyagupta/wpt-etw/tree/reduce-initial-json-serializeobject-cost-logging). The CPU cost of the exe while running against a light page comes down ~20% with this change (395ms to 321ms in our lab measured starting from navigation start). 

Example run before the change:
```
Forwarding ETW events to http://127.0.0.1:8888/
To exit, hit ctrl-C or create the file C:\Repos\wpt-etw\bin\Release\wpt-etw.done
Serialized ETW event into 162 bytes of Json in 1044154 ticks (104 ms)
Serialized ETW event into 336 bytes of Json in 23028 ticks (2 ms)
Serialized ETW event into 160 bytes of Json in 16729 ticks (1 ms)
Serialized ETW event into 358 bytes of Json in 513 ticks (0 ms)
Serialized ETW event into 196 bytes of Json in 430 ticks (0 ms)
Serialized ETW event into 193 bytes of Json in 333 ticks (0 ms)
Serialized ETW event into 197 bytes of Json in 478 ticks (0 ms)
Serialized ETW event into 3818 bytes of Json in 4829 ticks (0 ms)
Serialized ETW event into 181 bytes of Json in 337 ticks (0 ms)
Serialized ETW event into 178 bytes of Json in 332 ticks (0 ms)
Serialized ETW event into 213 bytes of Json in 342 ticks (0 ms)
Serialized ETW event into 211 bytes of Json in 347 ticks (0 ms)
Serialized ETW event into 220 bytes of Json in 343 ticks (0 ms)
Serialized ETW event into 245 bytes of Json in 347 ticks (0 ms)
```

After the change:
```
Forwarding ETW events to http://127.0.0.1:8888/
To exit, hit ctrl-C or create the file C:\Repos\wpt-etw\bin\Release\wpt-etw.done
Serialized ETW event into 162 bytes of Json in 131536 ticks (13 ms)
Serialized ETW event into 204 bytes of Json in 22865 ticks (2 ms)
Serialized ETW event into 160 bytes of Json in 16410 ticks (1 ms)
Serialized ETW event into 143 bytes of Json in 324 ticks (0 ms)
Serialized ETW event into 145 bytes of Json in 276 ticks (0 ms)
Serialized ETW event into 193 bytes of Json in 280 ticks (0 ms)
Serialized ETW event into 191 bytes of Json in 436 ticks (0 ms)
Serialized ETW event into 145 bytes of Json in 488 ticks (0 ms)
Serialized ETW event into 145 bytes of Json in 335 ticks (0 ms)
Serialized ETW event into 181 bytes of Json in 594 ticks (0 ms)
Serialized ETW event into 179 bytes of Json in 353 ticks (0 ms)
Serialized ETW event into 162 bytes of Json in 580 ticks (0 ms)
Serialized ETW event into 236 bytes of Json in 678 ticks (0 ms)
Serialized ETW event into 160 bytes of Json in 366 ticks (0 ms)
```
